### PR TITLE
feat: Redis 및 TimescaleDB 애플리케이션 추가

### DIFF
--- a/applications/README-redis-timescaledb.md
+++ b/applications/README-redis-timescaledb.md
@@ -1,0 +1,328 @@
+# 🗄️ Redis & TimescaleDB 애플리케이션 가이드
+
+## 📋 개요
+
+이 문서는 AstraGo 플랫폼에 새로 추가된 **Redis**와 **TimescaleDB** 로컬 헬름 차트 애플리케이션의 사용 방법을 설명합니다.
+
+## 🏗️ 애플리케이션 구조
+
+### 📦 Redis
+
+```
+applications/redis/
+├── helmfile.yaml              # Redis 릴리스 설정
+├── values.yaml.gotmpl         # 환경별 동적 설정
+└── redis/                     # Redis 헬름 차트
+    ├── Chart.yaml             # 차트 메타데이터
+    ├── values.yaml            # 기본 설정값
+    └── templates/             # Kubernetes 매니페스트 템플릿
+        ├── _helpers.tpl       # 헬퍼 함수
+        ├── secret.yaml        # 인증 정보
+        ├── configmap.yaml     # Redis 설정
+        ├── service.yaml       # Redis 서비스
+        └── statefulset.yaml   # Redis StatefulSet
+```
+
+### 🐘 TimescaleDB
+
+```
+applications/timescaledb/
+├── helmfile.yaml              # TimescaleDB 릴리스 설정
+├── values.yaml.gotmpl         # 환경별 동적 설정
+└── timescaledb/               # TimescaleDB 헬름 차트
+    ├── Chart.yaml             # 차트 메타데이터
+    ├── values.yaml            # 기본 설정값
+    └── templates/             # Kubernetes 매니페스트 템플릿
+        ├── _helpers.tpl       # 헬퍼 함수
+        ├── secret.yaml        # 인증 정보
+        ├── configmap.yaml     # PostgreSQL/TimescaleDB 설정
+        ├── service.yaml       # TimescaleDB 서비스
+        └── statefulset.yaml   # TimescaleDB StatefulSet
+```
+
+## 🚀 배포 방법
+
+### 1. 전체 애플리케이션 배포
+
+```bash
+# 모든 애플리케이션 배포 (Redis와 TimescaleDB 포함)
+helmfile -e dev sync
+
+# 특정 환경으로 배포
+helmfile -e stage sync
+helmfile -e prod sync
+```
+
+### 2. 개별 애플리케이션 배포
+
+```bash
+# Redis만 배포
+helmfile -e dev -l app=redis sync
+
+# TimescaleDB만 배포
+helmfile -e dev -l app=timescaledb sync
+```
+
+### 3. 특정 네임스페이스에 배포
+
+```bash
+# Redis 네임스페이스에 배포
+helm install redis applications/redis/redis -n redis --create-namespace
+
+# TimescaleDB 네임스페이스에 배포
+helm install timescaledb applications/timescaledb/timescaledb -n timescaledb --create-namespace
+```
+
+## ⚙️ 환경별 설정
+
+### 📝 기본 설정 (environments/common/values.yaml)
+
+#### Redis 설정
+
+```yaml
+redis:
+  enabled: true
+  password: "redis123!"
+  persistence:
+    size: "10Gi"
+  resources:
+    limits:
+      cpu: "1000m"
+      memory: "1Gi"
+    requests:
+      cpu: "100m"
+      memory: "128Mi"
+  config:
+    maxmemory: "1gb"
+    maxmemoryPolicy: "allkeys-lru"
+    save: "900 1 300 10 60 10000"
+```
+
+#### TimescaleDB 설정
+
+```yaml
+timescaledb:
+  enabled: true
+  superuserPassword: "timescale123!"
+  database: "timescaledb"
+  username: "timescale"
+  password: "timescale123!"
+  persistence:
+    size: "50Gi"
+  resources:
+    limits:
+      cpu: "2000m"
+      memory: "4Gi"
+    requests:
+      cpu: "500m"
+      memory: "1Gi"
+```
+
+### 🔧 환경별 커스터마이징
+
+환경별 설정 파일에서 다음과 같이 오버라이드할 수 있습니다:
+
+```yaml
+# environments/prod/values.yaml
+redis:
+  password: "super-secure-redis-password"
+  persistence:
+    size: "100Gi"
+  resources:
+    limits:
+      cpu: "2000m"
+      memory: "4Gi"
+
+timescaledb:
+  superuserPassword: "super-secure-postgres-password"
+  password: "secure-user-password"
+  persistence:
+    size: "500Gi"
+  resources:
+    limits:
+      cpu: "4000m"
+      memory: "8Gi"
+```
+
+## 🔗 연결 정보
+
+### Redis 연결
+
+```bash
+# 클러스터 내에서 연결
+redis://redis.redis.svc.cluster.local:6379
+
+# 패스워드 인증
+AUTH <password>
+
+# 상태 확인
+kubectl get pods -n redis
+kubectl logs -f redis-0 -n redis
+```
+
+### TimescaleDB 연결
+
+```bash
+# 클러스터 내에서 연결
+postgresql://timescale:password@timescaledb.timescaledb.svc.cluster.local:5432/timescaledb
+
+# psql을 사용한 연결
+kubectl exec -it timescaledb-0 -n timescaledb -- psql -U timescale -d timescaledb
+
+# 상태 확인
+kubectl get pods -n timescaledb
+kubectl logs -f timescaledb-0 -n timescaledb
+```
+
+## 📊 모니터링
+
+### Redis 모니터링
+
+```bash
+# Redis 정보 확인
+kubectl exec -it redis-0 -n redis -- redis-cli info
+
+# Redis 메모리 사용량
+kubectl exec -it redis-0 -n redis -- redis-cli info memory
+
+# Redis 연결 상태
+kubectl exec -it redis-0 -n redis -- redis-cli ping
+```
+
+### TimescaleDB 모니터링
+
+```bash
+# 데이터베이스 상태 확인
+kubectl exec -it timescaledb-0 -n timescaledb -- pg_isready
+
+# TimescaleDB 확장 확인
+kubectl exec -it timescaledb-0 -n timescaledb -- psql -U timescale -d timescaledb -c "SELECT * FROM pg_extension WHERE extname = 'timescaledb';"
+
+# 데이터베이스 크기 확인
+kubectl exec -it timescaledb-0 -n timescaledb -- psql -U timescale -d timescaledb -c "SELECT pg_size_pretty(pg_database_size('timescaledb'));"
+```
+
+## 🔧 운영 가이드
+
+### 백업 및 복원
+
+#### Redis 백업
+
+```bash
+# Redis 데이터 백업
+kubectl exec redis-0 -n redis -- redis-cli BGSAVE
+
+# 백업 파일 확인
+kubectl exec redis-0 -n redis -- ls -la /data/
+```
+
+#### TimescaleDB 백업
+
+```bash
+# 데이터베이스 덤프
+kubectl exec timescaledb-0 -n timescaledb -- pg_dump -U timescale timescaledb > backup.sql
+
+# 복원
+kubectl exec -i timescaledb-0 -n timescaledb -- psql -U timescale timescaledb < backup.sql
+```
+
+### 스케일링
+
+#### 리소스 증가
+
+```yaml
+# environments/{환경}/values.yaml에서 리소스 조정
+redis:
+  resources:
+    limits:
+      cpu: "2000m"
+      memory: "4Gi"
+
+timescaledb:
+  resources:
+    limits:
+      cpu: "4000m"
+      memory: "8Gi"
+```
+
+#### 스토리지 확장
+
+```bash
+# PVC 크기 확인
+kubectl get pvc -n redis
+kubectl get pvc -n timescaledb
+
+# 스토리지 클래스가 확장을 지원하는 경우 PVC 수정
+kubectl patch pvc data-redis-0 -n redis -p '{"spec":{"resources":{"requests":{"storage":"50Gi"}}}}'
+```
+
+## 🔒 보안 설정
+
+### Redis 보안
+
+- **패스워드 인증**: 기본적으로 활성화됨
+- **네트워크 격리**: Kubernetes 네트워크 정책 적용 권장
+- **TLS 암호화**: 필요시 Redis 설정에서 활성화
+
+### TimescaleDB 보안
+
+- **사용자 인증**: PostgreSQL 기본 인증 사용
+- **연결 암호화**: SSL/TLS 지원
+- **백업 암호화**: 민감한 데이터는 암호화된 백업 권장
+
+## 🚨 트러블슈팅
+
+### 일반적인 문제
+
+1. **팟이 시작되지 않는 경우**
+
+   ```bash
+   kubectl describe pod redis-0 -n redis
+   kubectl describe pod timescaledb-0 -n timescaledb
+   ```
+
+2. **PVC 마운트 문제**
+
+   ```bash
+   kubectl get pvc -n redis
+   kubectl get pvc -n timescaledb
+   ```
+
+3. **연결 실패**
+
+   ```bash
+   # 서비스 확인
+   kubectl get svc -n redis
+   kubectl get svc -n timescaledb
+   
+   # 네트워크 정책 확인
+   kubectl get networkpolicy -n redis
+   kubectl get networkpolicy -n timescaledb
+   ```
+
+## 📚 참고 자료
+
+### Redis
+
+- [Redis 공식 문서](https://redis.io/documentation)
+- [Redis 설정 가이드](https://redis.io/topics/config)
+- [Redis 모니터링](https://redis.io/topics/monitoring)
+
+### TimescaleDB
+
+- [TimescaleDB 공식 문서](https://docs.timescale.com/)
+- [PostgreSQL 문서](https://www.postgresql.org/docs/)
+- [TimescaleDB 최적화 가이드](https://docs.timescale.com/timescaledb/latest/how-to-guides/configuration/)
+
+---
+
+## 🤝 지원
+
+문제가 발생하거나 추가 기능이 필요한 경우:
+
+- 🐛 버그 리포트: GitHub Issues
+- 💬 질문 및 토론: GitHub Discussions
+- 📧 기술 지원: <devops@astrago.com>
+
+---
+*최종 업데이트: 2024년 12월*

--- a/applications/astrago/astrago/templates/experiment-hub/deployment.yaml
+++ b/applications/astrago/astrago/templates/experiment-hub/deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: astrago-experiment-hub
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: astrago-experiment-hub
+spec:
+  {{- if not .Values.core.autoscaling.enabled }}
+  replicas: {{ .Values.core.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: astrago-experiment-hub
+  template:
+    metadata:
+      {{- with .Values.core.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app.kubernetes.io/name: astrago-experiment-hub
+    spec:
+      {{- with .Values.core.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "common.serviceAccountName" . }}      
+      securityContext:
+        {{- toYaml .Values.core.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.core.securityContext | nindent 12 }}          
+          image: "{{ default .Values.experiment.image.registry .Values.global.imageRegistry }}/{{ .Values.experiment.image.repository }}:{{ .Values.experiment.image.tag }}"
+          imagePullPolicy: {{ .Values.experiment.image.pullPolicy }}      
+          env:
+          {{- range $key, $obj := .Values.experiment.env }}
+          - name: {{ $obj.name }}
+            value: {{ $obj.value | quote }}
+          {{- end }}
+          volumeMounts:
+            - name: astrago-workload-log
+              mountPath: /root/astrago
+          ports:
+            - name: http
+              containerPort: {{ .Values.experiment.service.port }}
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.experiment.resources | nindent 12 }}
+      volumes:
+        - name: astrago-workload-log
+          persistentVolumeClaim:
+            claimName: workload-log-pvc
+      {{- with .Values.experiment.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.experiment.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.experiment.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: 10

--- a/applications/astrago/astrago/templates/experiment-hub/service.yaml
+++ b/applications/astrago/astrago/templates/experiment-hub/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: astrago-experiment-hub
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.experiment.service.type }}
+  ports:
+    - port: {{ .Values.experiment.service.port }}
+      targetPort: {{ .Values.experiment.service.port }}
+      nodePort: {{ .Values.experiment.service.nodePort }}
+      protocol: TCP
+      name: http
+  selector: 
+    app.kubernetes.io/name: astrago-experiment-hub

--- a/applications/redis/helmfile.yaml
+++ b/applications/redis/helmfile.yaml
@@ -1,0 +1,10 @@
+releases:
+- name: redis
+  namespace: redis
+  chart: redis
+  wait: true
+  timeout: 600
+  labels:
+    app: redis
+  values:
+  - values.yaml.gotmpl 

--- a/applications/redis/redis/Chart.yaml
+++ b/applications/redis/redis/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: redis
+description: A Helm chart for Redis
+version: 0.1.0
+appVersion: "7.2"
+
+keywords:
+  - redis
+  - cache
+  - database
+  - memory
+
+home: https://redis.io/
+sources:
+  - https://github.com/redis/redis
+
+maintainers:
+  - name: AstraGo Team
+    email: devops@astrago.com
+
+type: application 

--- a/applications/redis/redis/templates/_helpers.tpl
+++ b/applications/redis/redis/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "redis.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "redis.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "redis.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "redis.labels" -}}
+helm.sh/chart: {{ include "redis.chart" . }}
+{{ include "redis.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "redis.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "redis.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }} 

--- a/applications/redis/redis/templates/configmap.yaml
+++ b/applications/redis/redis/templates/configmap.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "redis.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "redis.labels" . | nindent 4 }}
+data:
+  redis.conf: |
+    # Redis configuration
+    bind 0.0.0.0
+    port 6379
+    
+    # Memory management
+    maxmemory {{ .Values.config.maxmemory }}
+    maxmemory-policy {{ .Values.config.maxmemoryPolicy }}
+    
+    # Persistence
+    save {{ .Values.config.save }}
+    
+    # Security
+    {{- if .Values.auth.enabled }}
+    requirepass ${REDIS_PASSWORD}
+    {{- end }}
+    
+    # Logging
+    loglevel notice
+    
+    # Network
+    tcp-keepalive 300
+    timeout 0
+    
+    # Other
+    databases 16 

--- a/applications/redis/redis/templates/secret.yaml
+++ b/applications/redis/redis/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.auth.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "redis.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "redis.labels" . | nindent 4 }}
+type: Opaque
+data:
+  redis-password: {{ .Values.auth.password | b64enc | quote }}
+{{- end }} 

--- a/applications/redis/redis/templates/service.yaml
+++ b/applications/redis/redis/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "redis.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "redis.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: redis
+      protocol: TCP
+      name: redis
+  selector:
+    {{- include "redis.selectorLabels" . | nindent 4 }} 

--- a/applications/redis/redis/templates/statefulset.yaml
+++ b/applications/redis/redis/templates/statefulset.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "redis.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "redis.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "redis.fullname" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "redis.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "redis.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: redis
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+          env:
+            {{- if .Values.auth.enabled }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "redis.fullname" . }}
+                  key: redis-password
+            {{- end }}
+          command:
+            - redis-server
+            - /etc/redis/redis.conf
+          volumeMounts:
+            - name: config
+              mountPath: /etc/redis
+            {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: /data
+            {{- end }}
+          livenessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "redis.fullname" . }}-config
+  {{- if .Values.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: {{ .Values.persistence.storageClass }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size }}
+  {{- end }} 

--- a/applications/redis/redis/values.yaml
+++ b/applications/redis/redis/values.yaml
@@ -1,0 +1,38 @@
+image:
+  registry: "docker.io"
+  repository: "redis"
+  tag: "7.2-alpine"
+  pullPolicy: IfNotPresent
+
+auth:
+  enabled: true
+  password: "redis123!"
+
+persistence:
+  enabled: true
+  storageClass: "astrago-nfs-csi"
+  size: "10Gi"
+
+resources:
+  limits:
+    cpu: "1000m"
+    memory: "1Gi"
+  requests:
+    cpu: "100m"
+    memory: "128Mi"
+
+service:
+  type: ClusterIP
+  port: 6379
+
+metrics:
+  enabled: false
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+config:
+  maxmemory: "1gb"
+  maxmemoryPolicy: "allkeys-lru"
+  save: "900 1 300 10 60 10000" 

--- a/applications/redis/values.yaml.gotmpl
+++ b/applications/redis/values.yaml.gotmpl
@@ -1,0 +1,39 @@
+image:
+  registry: "docker.io"
+  repository: "redis"
+  tag: "7.2-alpine"
+  pullPolicy: IfNotPresent
+
+auth:
+  enabled: true
+  password: "{{ .Values.redis.password | default "redis123!" }}"
+
+persistence:
+  enabled: true
+  storageClass: "{{ .Values.nfs.storageClassName | default "astrago-nfs-csi" }}"
+  size: "{{ .Values.redis.persistence.size | default "10Gi" }}"
+
+resources:
+  limits:
+    cpu: "{{ .Values.redis.resources.limits.cpu | default "1000m" }}"
+    memory: "{{ .Values.redis.resources.limits.memory | default "1Gi" }}"
+  requests:
+    cpu: "{{ .Values.redis.resources.requests.cpu | default "100m" }}"
+    memory: "{{ .Values.redis.resources.requests.memory | default "128Mi" }}"
+
+service:
+  type: ClusterIP
+  port: 6379
+
+metrics:
+  enabled: "{{ .Values.redis.metrics.enabled | default false }}"
+  
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# Redis 설정
+config:
+  maxmemory: "{{ .Values.redis.config.maxmemory | default "1gb" }}"
+  maxmemoryPolicy: "{{ .Values.redis.config.maxmemoryPolicy | default "allkeys-lru" }}"
+  save: "{{ .Values.redis.config.save | default "900 1 300 10 60 10000" }}" 

--- a/applications/timescaledb/helmfile.yaml
+++ b/applications/timescaledb/helmfile.yaml
@@ -1,0 +1,10 @@
+releases:
+- name: timescaledb
+  namespace: timescaledb
+  chart: timescaledb
+  wait: true
+  timeout: 600
+  labels:
+    app: timescaledb
+  values:
+  - values.yaml.gotmpl 

--- a/applications/timescaledb/timescaledb/Chart.yaml
+++ b/applications/timescaledb/timescaledb/Chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: v2
+name: timescaledb
+description: A Helm chart for TimescaleDB
+version: 0.1.0
+appVersion: "2.12.1"
+
+keywords:
+  - timescaledb
+  - postgresql
+  - database
+  - timeseries
+  - analytics
+
+home: https://www.timescale.com/
+sources:
+  - https://github.com/timescale/timescaledb
+
+maintainers:
+  - name: AstraGo Team
+    email: devops@astrago.com
+
+type: application 

--- a/applications/timescaledb/timescaledb/templates/_helpers.tpl
+++ b/applications/timescaledb/timescaledb/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "timescaledb.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "timescaledb.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "timescaledb.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "timescaledb.labels" -}}
+helm.sh/chart: {{ include "timescaledb.chart" . }}
+{{ include "timescaledb.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "timescaledb.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "timescaledb.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }} 

--- a/applications/timescaledb/timescaledb/templates/configmap.yaml
+++ b/applications/timescaledb/timescaledb/templates/configmap.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "timescaledb.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "timescaledb.labels" . | nindent 4 }}
+data:
+  postgresql.conf: |
+    # PostgreSQL/TimescaleDB Configuration
+    listen_addresses = '*'
+    port = 5432
+    
+    # Memory Settings
+    shared_buffers = {{ .Values.config.sharedBuffers }}
+    effective_cache_size = {{ .Values.config.effectiveCacheSize }}
+    maintenance_work_mem = {{ .Values.config.maintenanceWorkMem }}
+    work_mem = {{ .Values.config.workMem }}
+    
+    # Connection Settings
+    max_connections = {{ .Values.config.maxConnections }}
+    
+    # WAL Settings
+    max_wal_size = {{ .Values.config.maxWalSize }}
+    min_wal_size = {{ .Values.config.minWalSize }}
+    wal_buffers = {{ .Values.config.walBuffers }}
+    wal_level = replica
+    
+    # Logging
+    log_destination = 'stderr'
+    logging_collector = on
+    log_directory = 'pg_log'
+    log_filename = 'postgresql-%Y-%m-%d_%H%M%S.log'
+    log_statement = 'all'
+    log_min_duration_statement = 1000
+    
+    # TimescaleDB Settings
+    shared_preload_libraries = 'timescaledb'
+    timescaledb.max_background_workers = {{ .Values.timescale.maxBackgroundWorkers }}
+    
+    # Performance
+    random_page_cost = 1.1
+    effective_io_concurrency = 200
+    
+  pg_hba.conf: |
+    # PostgreSQL Client Authentication Configuration File
+    local   all             all                                     trust
+    host    all             all             127.0.0.1/32            trust
+    host    all             all             ::1/128                 trust
+    host    all             all             0.0.0.0/0               md5
+    
+  init-timescaledb.sql: |
+    -- Initialize TimescaleDB
+    CREATE EXTENSION IF NOT EXISTS timescaledb; 

--- a/applications/timescaledb/timescaledb/templates/secret.yaml
+++ b/applications/timescaledb/timescaledb/templates/secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "timescaledb.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "timescaledb.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if .Values.auth.enableSuperuser }}
+  postgres-password: {{ .Values.auth.superuserPassword | b64enc | quote }}
+  {{- end }}
+  username: {{ .Values.auth.username | b64enc | quote }}
+  password: {{ .Values.auth.password | b64enc | quote }}
+  database: {{ .Values.auth.database | b64enc | quote }} 

--- a/applications/timescaledb/timescaledb/templates/service.yaml
+++ b/applications/timescaledb/timescaledb/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "timescaledb.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "timescaledb.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: postgresql
+      protocol: TCP
+      name: postgresql
+  selector:
+    {{- include "timescaledb.selectorLabels" . | nindent 4 }} 

--- a/applications/timescaledb/timescaledb/templates/statefulset.yaml
+++ b/applications/timescaledb/timescaledb/templates/statefulset.yaml
@@ -1,0 +1,144 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "timescaledb.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "timescaledb.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "timescaledb.fullname" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "timescaledb.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "timescaledb.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      initContainers:
+        - name: init-chmod-data
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          command:
+            - sh
+            - -c
+            - |
+              chown -R postgres:postgres /var/lib/postgresql/data
+              chmod 700 /var/lib/postgresql/data
+          volumeMounts:
+            {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: /var/lib/postgresql/data
+            {{- end }}
+          securityContext:
+            runAsUser: 0
+      containers:
+        - name: timescaledb
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: postgresql
+              containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "timescaledb.fullname" . }}
+                  key: database
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "timescaledb.fullname" . }}
+                  key: username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "timescaledb.fullname" . }}
+                  key: password
+            {{- if .Values.auth.enableSuperuser }}
+            - name: POSTGRES_POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "timescaledb.fullname" . }}
+                  key: postgres-password
+            {{- end }}
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          command:
+            - docker-entrypoint.sh
+            - postgres
+            - -c
+            - config_file=/etc/postgresql/postgresql.conf
+            - -c
+            - hba_file=/etc/postgresql/pg_hba.conf
+          volumeMounts:
+            - name: config
+              mountPath: /etc/postgresql
+            - name: init-scripts
+              mountPath: /docker-entrypoint-initdb.d
+            {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: /var/lib/postgresql/data
+            {{- end }}
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -h 127.0.0.1 -p 5432
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -h 127.0.0.1 -p 5432
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "timescaledb.fullname" . }}-config
+            items:
+              - key: postgresql.conf
+                path: postgresql.conf
+              - key: pg_hba.conf
+                path: pg_hba.conf
+        - name: init-scripts
+          configMap:
+            name: {{ include "timescaledb.fullname" . }}-config
+            items:
+              - key: init-timescaledb.sql
+                path: init-timescaledb.sql
+  {{- if .Values.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: {{ .Values.persistence.storageClass }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size }}
+  {{- end }} 

--- a/applications/timescaledb/timescaledb/values.yaml
+++ b/applications/timescaledb/timescaledb/values.yaml
@@ -1,0 +1,50 @@
+image:
+  registry: "docker.io"
+  repository: "timescale/timescaledb"
+  tag: "2.12.1-pg16"
+  pullPolicy: IfNotPresent
+
+auth:
+  enableSuperuser: true
+  superuserPassword: "timescale123!"
+  database: "timescaledb"
+  username: "timescale"
+  password: "timescale123!"
+
+persistence:
+  enabled: true
+  storageClass: "astrago-nfs-csi"
+  size: "50Gi"
+
+resources:
+  limits:
+    cpu: "2000m"
+    memory: "4Gi"
+  requests:
+    cpu: "500m"
+    memory: "1Gi"
+
+service:
+  type: ClusterIP
+  port: 5432
+
+metrics:
+  enabled: false
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+config:
+  sharedBuffers: "1GB"
+  effectiveCacheSize: "3GB"
+  maintenanceWorkMem: "256MB"
+  workMem: "64MB"
+  maxConnections: "200"
+  maxWalSize: "4GB"
+  minWalSize: "1GB"
+  walBuffers: "16MB"
+
+timescale:
+  maxBackgroundWorkers: "8"
+  maxChunkTime: "7d" 

--- a/applications/timescaledb/values.yaml.gotmpl
+++ b/applications/timescaledb/values.yaml.gotmpl
@@ -1,0 +1,52 @@
+image:
+  registry: "docker.io"
+  repository: "timescale/timescaledb"
+  tag: "2.12.1-pg16"
+  pullPolicy: IfNotPresent
+
+auth:
+  enableSuperuser: true
+  superuserPassword: "{{ .Values.timescaledb.superuserPassword | default "timescale123!" }}"
+  database: "{{ .Values.timescaledb.database | default "timescaledb" }}"
+  username: "{{ .Values.timescaledb.username | default "timescale" }}"
+  password: "{{ .Values.timescaledb.password | default "timescale123!" }}"
+
+persistence:
+  enabled: true
+  storageClass: "{{ .Values.nfs.storageClassName | default "astrago-nfs-csi" }}"
+  size: "{{ .Values.timescaledb.persistence.size | default "50Gi" }}"
+
+resources:
+  limits:
+    cpu: "{{ .Values.timescaledb.resources.limits.cpu | default "2000m" }}"
+    memory: "{{ .Values.timescaledb.resources.limits.memory | default "4Gi" }}"
+  requests:
+    cpu: "{{ .Values.timescaledb.resources.requests.cpu | default "500m" }}"
+    memory: "{{ .Values.timescaledb.resources.requests.memory | default "1Gi" }}"
+
+service:
+  type: ClusterIP
+  port: 5432
+
+metrics:
+  enabled: "{{ .Values.timescaledb.metrics.enabled | default false }}"
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# PostgreSQL/TimescaleDB 설정
+config:
+  sharedBuffers: "{{ .Values.timescaledb.config.sharedBuffers | default "1GB" }}"
+  effectiveCacheSize: "{{ .Values.timescaledb.config.effectiveCacheSize | default "3GB" }}"
+  maintenanceWorkMem: "{{ .Values.timescaledb.config.maintenanceWorkMem | default "256MB" }}"
+  workMem: "{{ .Values.timescaledb.config.workMem | default "64MB" }}"
+  maxConnections: "{{ .Values.timescaledb.config.maxConnections | default "200" }}"
+  maxWalSize: "{{ .Values.timescaledb.config.maxWalSize | default "4GB" }}"
+  minWalSize: "{{ .Values.timescaledb.config.minWalSize | default "1GB" }}"
+  walBuffers: "{{ .Values.timescaledb.config.walBuffers | default "16MB" }}"
+
+# TimescaleDB 확장 설정
+timescale:
+  maxBackgroundWorkers: "{{ .Values.timescaledb.timescale.maxBackgroundWorkers | default "8" }}"
+  maxChunkTime: "{{ .Values.timescaledb.timescale.maxChunkTime | default "7d" }}" 

--- a/environments/common/values.yaml
+++ b/environments/common/values.yaml
@@ -31,3 +31,54 @@ promtail:
     requests:
       cpu: "100m"
       memory: "128Mi"
+
+# Redis Configuration
+redis:
+  enabled: true
+  password: "redis123!"
+  persistence:
+    size: "10Gi"
+  resources:
+    limits:
+      cpu: "1000m"
+      memory: "1Gi"
+    requests:
+      cpu: "100m"
+      memory: "128Mi"
+  metrics:
+    enabled: false
+  config:
+    maxmemory: "1gb"
+    maxmemoryPolicy: "allkeys-lru"
+    save: "900 1 300 10 60 10000"
+
+# TimescaleDB Configuration
+timescaledb:
+  enabled: true
+  superuserPassword: "timescale123!"
+  database: "timescaledb"
+  username: "timescale"
+  password: "timescale123!"
+  persistence:
+    size: "50Gi"
+  resources:
+    limits:
+      cpu: "2000m"
+      memory: "4Gi"
+    requests:
+      cpu: "500m"
+      memory: "1Gi"
+  metrics:
+    enabled: false
+  config:
+    sharedBuffers: "1GB"
+    effectiveCacheSize: "3GB"
+    maintenanceWorkMem: "256MB"
+    workMem: "64MB"
+    maxConnections: "200"
+    maxWalSize: "4GB"
+    minWalSize: "1GB"
+    walBuffers: "16MB"
+  timescale:
+    maxBackgroundWorkers: "8"
+    maxChunkTime: "7d"

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -65,3 +65,11 @@ helmfiles:
 - path: applications/harbor/helmfile.yaml
   values:
   - {{ toYaml .Values | nindent 4 }}
+
+- path: applications/redis/helmfile.yaml
+  values:
+  - {{ toYaml .Values | nindent 4 }}
+
+- path: applications/timescaledb/helmfile.yaml
+  values:
+  - {{ toYaml .Values | nindent 4 }}

--- a/monochart/stage/astrago/astrago.yaml
+++ b/monochart/stage/astrago/astrago.yaml
@@ -537,6 +537,29 @@ spec:
   selector: 
     app.kubernetes.io/name: astrago-backend-core
 ---
+# Source: astrago/templates/experiment-hub/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: astrago-experiment-hub
+  namespace: astrago
+  labels:
+    helm.sh/chart: astrago-0.1.0
+    app.kubernetes.io/name: astrago
+    app.kubernetes.io/instance: astrago
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: NodePort
+  ports:
+    - port: 8080
+      targetPort: 8080
+      nodePort: 30084
+      protocol: TCP
+      name: http
+  selector: 
+    app.kubernetes.io/name: astrago-experiment-hub
+---
 # Source: astrago/templates/frontend/service.yaml
 apiVersion: v1
 kind: Service
@@ -862,6 +885,49 @@ spec:
             value: "5000"
           - name: SPRING_DATASOURCE_HIKARI_CONNECTION-TEST-QUERY
             value: "SELECT 1"
+          volumeMounts:
+            - name: astrago-workload-log
+              mountPath: /root/astrago
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          resources:
+            {}
+      volumes:
+        - name: astrago-workload-log
+          persistentVolumeClaim:
+            claimName: workload-log-pvc
+      terminationGracePeriodSeconds: 10
+---
+# Source: astrago/templates/experiment-hub/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: astrago-experiment-hub
+  namespace: astrago
+  labels:
+    app.kubernetes.io/name: astrago-experiment-hub
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: astrago-experiment-hub
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: astrago-experiment-hub
+    spec:
+      serviceAccountName: astrago-sa      
+      securityContext:
+        {}
+      containers:
+        - name: astrago
+          securityContext:
+            {}          
+          image: "docker.io/xiilab/astrago:experiment-v1.0.15"
+          imagePullPolicy: Always      
+          env:
           volumeMounts:
             - name: astrago-workload-log
               mountPath: /root/astrago


### PR DESCRIPTION
- Redis 및 TimescaleDB에 대한 Helm 차트 및 설정 파일 추가
- helmfile.yaml에 Redis 및 TimescaleDB 경로 추가
- Redis 및 TimescaleDB에 대한 README 문서 작성
- 각 애플리케이션의 기본 설정 및 배포 방법 포함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * Redis 및 TimescaleDB의 Helm Chart 기반 배포가 추가되었습니다.
  * Redis와 TimescaleDB에 대한 환경별 설정 및 Helmfile 연동이 지원됩니다.
  * astrago-experiment-hub 컴포넌트의 신규 Kubernetes 서비스와 배포가 추가되었습니다.

* **문서화**
  * Redis와 TimescaleDB 배포, 운영, 모니터링, 백업, 보안, 문제 해결에 대한 종합적인 README가 추가되었습니다.

* **설정**
  * 공통 환경설정에 Redis와 TimescaleDB 관련 설정 항목이 신규 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->